### PR TITLE
Update circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,7 +7,7 @@ dependencies:
 #    - cf -v
   post:
     - if [[ ! -e elasticsearch-1.7.5 ]]; then wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.5.tar.gz && tar -xvf elasticsearch-1.7.5.tar.gz; fi
-    - elasticsearch-1.7.1/bin/elasticsearch: {background: true}
+    - elasticsearch-1.7.5/bin/elasticsearch: {background: true}
 
 #test:
 #  post:

--- a/circle.yml
+++ b/circle.yml
@@ -1,23 +1,23 @@
 dependencies:
   cache_directories:
-    - elasticsearch-1.7.1
-  pre:
-    - curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
-    - sudo dpkg -i cf-cli_amd64.deb
-    - cf -v
+    - elasticsearch-1.7.5
+#  pre:
+#    - curl -v -L -o cf-cli_amd64.deb 'https://cli.run.pivotal.io/stable?release=debian64&source=github'
+#    - sudo dpkg -i cf-cli_amd64.deb
+#    - cf -v
   post:
-    - if [[ ! -e elasticsearch-1.7.1 ]]; then wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.1.tar.gz && tar -xvf elasticsearch-1.7.1.tar.gz; fi
+    - if [[ ! -e elasticsearch-1.7.5 ]]; then wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.5.tar.gz && tar -xvf elasticsearch-1.7.5.tar.gz; fi
     - elasticsearch-1.7.1/bin/elasticsearch: {background: true}
 
-test:
-  post:
-    - cf api https://api.cloud.gov
-    - cf auth $CF_USER $CF_PASSWORD
-    - cf target -o ed -s dev
-    - cf a
+#test:
+#  post:
+#    - cf api https://api.cloud.gov
+#    - cf auth $CF_USER $CF_PASSWORD
+#    - cf target -o ed -s dev
+#    - cf a
 
-deployment:
-  development:
-    branch: dev
-    commands:
-            - cf push -f manifest-dev.yml
+#deployment:
+#  development:
+#    branch: dev
+#    commands:
+#            - cf push -f manifest-dev.yml


### PR DESCRIPTION
this PR updates elasticsearch version from 1.7.1 to 1.7.5 in circle ci. Also, this disables deployment settings on the dev branch for the time being while we are between data releases and code changes that rely on new data may break dev.