### PR TITLE
add back location field type for lat lon field filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ db/*.db
 .env
 .*.env
 .cfignore
+cf-ssh.yml
 .vagrant
 .idea/
 *profile*

--- a/API.md
+++ b/API.md
@@ -210,7 +210,7 @@ By default, using the `_sort_` option returns records sorted into ascending orde
 When the dataset includes a `location` at the root level (`location.lat` and
 `location.lon`) then the documents will be indexed geographically. You can use the `_zip` and `_distance` options to narrow query results down to those within a geographic area. For example, `_zip=12345&_distance=10mi` will return only those results within 10 miles of the center of the given zip code.
 
-**Note: Due to a bug, specifying `location` and its sub-fields in certain field or option parameters may cause an error.** This is a known problem and tracked in this GitHub issue: _[Querying for a school by name and returning location.lon does not work](https://github.com/18F/open-data-maker/issues/227)_
+Additionally, you can request `location.lat` and `location.lat` in a search that includes a `_fields` filter and it will return the record(s) with respective lat and/or lon coordinates.
 
 #### Additional Notes on Geographic Filtering
 

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -171,7 +171,7 @@ module DataMagic
   def self.create_index(es_index_name = nil, field_types={})
     logger.info "create_index field_types: #{field_types.inspect[0..500]}"
     es_index_name ||= self.config.scoped_index_name
-    field_types['location'] = 'geo_point'
+    field_types['location'] = 'lat_lon' # custom lat_lon type maps to geo_point with additional field options
     es_types = NestedHash.new.add(es_field_types(field_types))
     nested_object_type(es_types)
     begin
@@ -234,6 +234,11 @@ module DataMagic
                           index_analyzer: 'autocomplete_index',
                           search_analyzer: 'autocomplete_search'
       },
+      'lat_lon' => { type: 'geo_point',
+                     lat_lon: true,
+                     store: true
+
+      }
    }
     field_types.each_with_object({}) do |(key, type), result|
       result[key] = custom_type[type]

--- a/lib/data_magic/config.rb
+++ b/lib/data_magic/config.rb
@@ -270,7 +270,6 @@ module DataMagic
         logger.info "field_types #{fields.inspect}"
         fields.each do |field_name, info|
           type = info['type'] || "string"
-          type = nil if field_name == 'location.lat' || field_name == 'location.lon'
           #logger.info "field #{field_name}: #{type.inspect}"
           @field_types[field_name] = type unless type.nil?
           if type == 'name' || type == 'autocomplete'

--- a/spec/features/api_spec.rb
+++ b/spec/features/api_spec.rb
@@ -141,8 +141,8 @@ describe 'api', type: 'feature' do
 
           expect(result.length).to eq 2
 
-          expect(result[0]).to eq %w(id code name state population area.land area.water location.lat location.lon)
-          expect(result[1]).to eq %w(1714000 00428803 Chicago IL 2695598 227.635 6.479 41.837551 -87.681844)
+          expect(result[0]).to eq %w(id code name state population location.lat location.lon area.land area.water)
+          expect(result[1]).to eq %w(1714000 00428803 Chicago IL 2695598 41.837551 -87.681844 227.635 6.479 )
         end
       end
 

--- a/spec/lib/data_magic/config_field_types_spec.rb
+++ b/spec/lib/data_magic/config_field_types_spec.rb
@@ -72,13 +72,17 @@ describe 'DataMagic::Config #field_types' do
     end
   end
 
-  it "supports special case for location fields as nil" do
-    # special case for location in create_index
+  it "supports location.lat and location.lon fields" do
+    allow(config).to receive(:file_config).and_return([{'name' => 'one.csv'}])
     allow(config).to receive(:dictionary).and_return(
-      IndifferentHash.new 'location.lat': {source:'LAT_COLUMN'},
-                          'location.lon': {source:'LON_COLUMN'}
-
+      IndifferentHash.new 'location.lat': {source:'LAT_COLUMN', type: 'float'},
+                          'location.lon': {source:'LON_COLUMN', type: 'float'}
     )
-    expect(config.field_types).to eq({})
+    expect(config.field_types).to eq(
+      {
+        'location.lat'=>'float',
+        'location.lon'=>'float'
+      }
+    )
   end
 end

--- a/spec/lib/data_magic/search_spec.rb
+++ b/spec/lib/data_magic/search_spec.rb
@@ -191,6 +191,18 @@ describe "DataMagic #search" do
       expected['metadata']["total"] = expected["results"].length
       expect(result).to eq(expected)
     end
+
+    it "#search with a fields filter can return location.lat and location.lon values" do
+      sf_location = { lat: 37.727239, lon: -123.032229 }
+      DataMagic.logger.debug "sfo_location[:lat] #{sf_location[:lat].class} #{sf_location[:lat].inspect}"
+      response = DataMagic.search({city: "San Francisco"}, {:fields => ["location.lat", "location.lon"]})
+      result = response["results"][0]
+      expect(result.keys.length).to eq(2)
+      expect(result).to include("location.lat")
+      expect(result).to include("location.lat")
+      expect(result["location.lat"]).to eq sf_location[:lat]
+      expect(result["location.lon"]).to eq sf_location[:lon]
+    end
   end
 
   describe "with sample-data" do


### PR DESCRIPTION
This PR address 18F/open-data-maker#227, where `location.lat` and `location.lon` values are not being returned in a fields search because they are explicitly being excluded from the [field_types](https://github.com/18F/open-data-maker/blob/dev/lib/data_magic/config.rb#L273) and the error checker kicks out the request. 

The above issue mentions excluding `lat` and `lon` was done on a special case for the location field (necessary for geo search by distance?), however, I don't see any issue that keeping lat/lon has an affect on a distance search.

Additionally, in order to store and index the `lat` and `lon` so as to return them in a fields filter query, we need to set the `lat_lon` mapping option for the `location` field's [geo_point](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/mapping-geo-point-type.html#_mapping_options) type. The `lat_lon` option will then index these values as fields.

Also needed to update a couple tests that we're expecting lat/lon to not be able to return results as well as added a test for a field filter query to return coordinates.