### PR TITLE
Check for multiple s3 key names for using the s3_bucket_service

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -44,17 +44,8 @@ module DataMagic
       s3cred = {}
       if ENV['VCAP_APPLICATION']
         s3cred = ::CF::App::Credentials.find_by_service_name(ENV['s3_bucket_service'] || 'bservice')
-      end
-      if ENV.has_key?('s3_access_key') && ENV.has_key?('s3_secret_key')
-        if s3cred.empty?
-        s3cred = {
-            'access_key' => ENV['s3_access_key'],
-            'secret_key' => ENV['s3_secret_key']
-        }
-        else
-          s3cred['access_key'] = ENV['s3_access_key']
-          s3cred['secret_key'] = ENV['s3_secret_key']
-        end
+      else
+        s3cred = {'access_key'=>  ENV['s3_access_key'], 'secret_key' => ENV['s3_secret_key']}
       end
       logger.info "s3cred = #{s3cred.inspect}"
       if ENV['RACK_ENV'] != 'test'


### PR DESCRIPTION
This PR updates how we provision the s3 client by allowing the credentials to be completely set in the environment, even if running in cloud foundry. This helps when we are using different kinds of services instances (`user-provided` or `s3`) and keys are stored in different places, with different names.

This also checks to see if the credentials are set in another key, to allow for an s3 client provided by an  `s3` cloud foundry service instance.