### PR TITLE
Update autocomplete ES filters and use whitespace tokenizer

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -193,37 +193,44 @@ module DataMagic
 
   def self.base_index_hash(es_index_name, es_types)
     {
-      index: es_index_name,
-      body: {
-        settings: {
-          analysis: {
-            filter: {
-              autocomplete_filter: {
-                  type: 'edge_ngram',
-                  min_gram: 3,
-                  max_gram: 25
-              }
+        index: es_index_name,
+        body: {
+            settings: {
+                analysis: {
+                    filter: {
+                        autocomplete_filter: {
+                            type: 'edge_ngram',
+                            min_gram: 1,
+                            max_gram: 25,
+                        },
+                        autocomplete_word_delimiter: {
+                            type: 'word_delimiter',
+                            preserve_original: true,
+                            split_on_case_change:false,
+                            split_on_numerics: false,
+                            stem_english_possessive:false
+                        }
+                    },
+                    analyzer: {
+                        autocomplete_index: {
+                            tokenizer: 'whitespace',
+                            filter: ['lowercase', 'autocomplete_word_delimiter', 'autocomplete_filter'],
+                            type: 'custom'
+                        },
+                        autocomplete_search: {
+                            tokenizer: 'whitespace',
+                            filter: ['lowercase','autocomplete_word_delimiter'],
+                            type: 'custom'
+                        }
+                    }
+                }
             },
-            analyzer: {
-              autocomplete_index: {
-                tokenizer: 'standard',
-                filter: ['lowercase', 'stop', 'autocomplete_filter'],
-                type: 'custom'
-              },
-              autocomplete_search: {
-                tokenizer: 'standard',
-                filter: ['lowercase', 'stop'],
-                type: 'custom'
-              }
+            mappings: {
+                document: { # type 'document' is always used for external indexed docs
+                   properties: es_types
+                }
             }
-          }
-        },
-        mappings: {
-          document: { # type 'document' is always used for external indexed docs
-            properties: es_types
-          }
         }
-      }
     }
   end
 


### PR DESCRIPTION
This PR is an update to the elastic search config for the `autocomplete` type on both index and search analyzers. The main differences here are:

- Lower the edge_ngram `min_gram` to `1`.
  - In order to pickup terms that are significant, however maybe very short (`el paso`, `la verne`) or resemble stop words (`A & M`).
- Remove `stop` words filter. 
  - The existing `autocomplete` [query ](https://github.com/RTICWDT/open-data-maker/blob/dev/lib/data_magic/query_builder.rb#L112-L121) is using the `common` query which effectively is already dynamically dropping common words (including stop words) according to some of the supplied parameters. see [this post](https://www.elastic.co/blog/stop-stopping-stop-words-a-look-at-common-terms-query) for more on the common query.
- Switch to `whitespace` tokenizer.
  - The current `standard` tokenizer is dropping some special characters that when supplied to a query (in the context of our `common` query using an `and` for low frequency terms) will not match as the special character would be missing from any indexed documents. Using the  `whitespace` tokenizer for indexing and searching, we instead only split on whitespace and allow terms with `-` `&` and others that join words.
- Add `word_delimiter` filter.
  - To account for some `subwords` that the `whitespace` tokenizer would lose, for example `California-Berkeley`, we add the `word_delimiter` filter that will again split on special characters. This is only helpful when specifying the `preserve_original` flag so that we can also index the original term so as to keep any hyphenated or other joined words. I think this is helpful in scenarios like the Berkeley example where the words can be searched independently, as well as it appears in the name. Additionally helpful when one of the two words may be a common (high frequency word).