### PR TITLE
API Key Documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -7,6 +7,9 @@ This document explains:
  * Extracting query results in JSON and CSV format
  * Detecting query errors
 
+## API Access for the College Scorecard Data
+Please note: A valid API key is required for those looking to access the API for the [College Scorecard Data](https://collegescorecard.ed.gov/data/documentation/), which is proxied through an API gateway. Developers may register a key at https://api.data.gov/signup for API access.
+
 ## Introduction to Queries
 
 Each query is expressed as a URL, containing:


### PR DESCRIPTION
This updates the [API documentation](https://github.com/RTICWDT/open-data-maker/blob/dev/API.md) to include a link to the API key signup page for this interested in accessing the [College Scorecard Data](https://collegescorecard.ed.gov/data/documentation/).

This supersedes #60.