### PR TITLE
Update actionview and deps

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,13 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actionview (5.2.2.1)
-      activesupport (= 5.2.2.1)
+    actionview (5.2.3)
+      activesupport (= 5.2.3)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activesupport (5.2.2.1)
+    activesupport (5.2.3)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -70,7 +70,7 @@ GEM
     mustermann19 (0.4.4)
       enumerable-lazy
     newrelic_rpm (3.18.1.330)
-    nokogiri (1.10.1)
+    nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
     oj (2.12.13)
     padrino (0.13.3.4)


### PR DESCRIPTION
This updates `actionview` gem to v5.2.3 which includes an update for `nokogiri` to v1.10.3 (patches CVE-2019-11068).