### PR TITLE
Increase max page size of 100 to 1000 as there are 7112+ records currently

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -34,6 +34,7 @@ module DataMagic
   end
 
   DEFAULT_PAGE_SIZE = 20
+  MAX_PAGE_SIZE = 100
   DEFAULT_EXTENSIONS = ['.csv']
   DEFAULT_PATH = './sample-data'
   class InvalidData < StandardError

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -34,7 +34,6 @@ module DataMagic
   end
 
   DEFAULT_PAGE_SIZE = 20
-  MAX_PAGE_SIZE = 100
   DEFAULT_EXTENSIONS = ['.csv']
   DEFAULT_PATH = './sample-data'
   class InvalidData < StandardError

--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -34,7 +34,7 @@ module DataMagic
   end
 
   DEFAULT_PAGE_SIZE = 20
-  MAX_PAGE_SIZE = 100
+  MAX_PAGE_SIZE = 1000
   DEFAULT_EXTENSIONS = ['.csv']
   DEFAULT_PATH = './sample-data'
   class InvalidData < StandardError

--- a/lib/data_magic/query_builder.rb
+++ b/lib/data_magic/query_builder.rb
@@ -12,7 +12,6 @@ module DataMagic
         set_dictionary(config)
         per_page = (options[:per_page] || config.page_size || DataMagic::DEFAULT_PAGE_SIZE).to_i
         page = options[:page].to_i || 0
-        per_page = DataMagic::MAX_PAGE_SIZE if per_page > DataMagic::MAX_PAGE_SIZE
 
         query_hash = {
           post_es_response: {},

--- a/lib/data_magic/query_builder.rb
+++ b/lib/data_magic/query_builder.rb
@@ -12,6 +12,7 @@ module DataMagic
         set_dictionary(config)
         per_page = (options[:per_page] || config.page_size || DataMagic::DEFAULT_PAGE_SIZE).to_i
         page = options[:page].to_i || 0
+        per_page = DataMagic::MAX_PAGE_SIZE if per_page > DataMagic::MAX_PAGE_SIZE
 
         query_hash = {
           post_es_response: {},

--- a/spec/lib/data_magic/query_builder_spec.rb
+++ b/spec/lib/data_magic/query_builder_spec.rb
@@ -89,14 +89,6 @@ describe DataMagic::QueryBuilder do
     it_correctly "builds a query"
   end
 
-  describe "limits maximum page size" do
-    subject { {} }
-    let(:options) { { page: 0, per_page: 2000 } }
-    let(:expected_query) { { match_all: {} } }
-    let(:expected_meta)  { { post_es_response: {}, from: 0, size: 100, _source: {:exclude=>["_*"]} }}
-    it_correctly "builds a query"
-  end
-
   describe "can specify fields to return" do
     before do
       ENV['DATA_PATH'] = './spec/fixtures/school_names'

--- a/spec/lib/data_magic/query_builder_spec.rb
+++ b/spec/lib/data_magic/query_builder_spec.rb
@@ -93,7 +93,7 @@ describe DataMagic::QueryBuilder do
     subject { {} }
     let(:options) { { page: 0, per_page: 2000 } }
     let(:expected_query) { { match_all: {} } }
-    let(:expected_meta)  { { post_es_response: {}, from: 0, size: 100, _source: {:exclude=>["_*"]} }}
+    let(:expected_meta)  { { post_es_response: {}, from: 0, size: 1000, _source: {:exclude=>["_*"]} }}
     it_correctly "builds a query"
   end
 

--- a/spec/lib/data_magic/query_builder_spec.rb
+++ b/spec/lib/data_magic/query_builder_spec.rb
@@ -89,6 +89,14 @@ describe DataMagic::QueryBuilder do
     it_correctly "builds a query"
   end
 
+  describe "limits maximum page size" do
+    subject { {} }
+    let(:options) { { page: 0, per_page: 2000 } }
+    let(:expected_query) { { match_all: {} } }
+    let(:expected_meta)  { { post_es_response: {}, from: 0, size: 100, _source: {:exclude=>["_*"]} }}
+    it_correctly "builds a query"
+  end
+
   describe "can specify fields to return" do
     before do
       ENV['DATA_PATH'] = './spec/fixtures/school_names'


### PR DESCRIPTION
Currently when performing a call to https://api.data.gov/ed/collegescorecard/v1/schools without selection parameters there is a total of 7112 records that can be retrieved however the max page size that is enforced is 100 which would require 72 rest calls to pull all of the data. 

I propose increasing the max page size so larger sets of data can be pulled at once

The rest call (missing an api key) I am using is https://api.data.gov/ed/collegescorecard/v1/schools?api_key=&fields=id,ope8_id,ope6_id,school,latest&per_page=1000&page=71 