### PR TITLE
Added size defualt parameter for nested queries.

### DIFF
--- a/lib/data_magic.rb
+++ b/lib/data_magic.rb
@@ -36,6 +36,7 @@ module DataMagic
 
   DEFAULT_PAGE_SIZE = 20
   MAX_PAGE_SIZE = 100
+  MAX_NESTED_RESULT = 1000
   DEFAULT_EXTENSIONS = ['.csv']
   DEFAULT_PATH = './sample-data'
   class InvalidData < StandardError

--- a/lib/data_magic/nested_query_builder.rb
+++ b/lib/data_magic/nested_query_builder.rb
@@ -213,7 +213,9 @@ module DataMagic
 					{ 
 						nested: {
 							path: path,
-							inner_hits: {}
+							inner_hits: {
+									size: DataMagic::MAX_NESTED_RESULT
+							}
 						}
 					}
 				end

--- a/spec/lib/data_magic/nested_and_non_nested_combos_spec.rb
+++ b/spec/lib/data_magic/nested_and_non_nested_combos_spec.rb
@@ -43,7 +43,9 @@ describe DataMagic::QueryBuilder do
   }}
   let(:nested_match) {{
     nested: {
-      inner_hits: {},
+      inner_hits: {
+          size: DataMagic::MAX_NESTED_RESULT
+      },
       path: "2016.programs.cip_4_digit",
       query: {
         bool: {

--- a/spec/lib/data_magic/nested_data_type_spec.rb
+++ b/spec/lib/data_magic/nested_data_type_spec.rb
@@ -40,7 +40,9 @@ describe DataMagic::QueryBuilder do
           bool: {
             filter: {
               nested: {
-                inner_hits: {},
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                },
                 path: "2016.programs.cip_4_digit",
                 query: {
                   bool: {
@@ -80,7 +82,9 @@ describe DataMagic::QueryBuilder do
           bool: {
             filter: {
               nested: {
-                inner_hits: {},
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                },
                 path: "2016.programs.cip_4_digit",
                 query: {
                   bool: {
@@ -117,7 +121,9 @@ describe DataMagic::QueryBuilder do
           bool: { 
             filter: {
               nested: {
-                inner_hits: {},
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                },
                 path: "2016.programs.cip_4_digit",
                 query: {
                   bool: {
@@ -144,7 +150,9 @@ describe DataMagic::QueryBuilder do
           bool: { 
             filter: {
               nested: {
-                inner_hits: {},
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                },
                 path: "2016.programs.cip_4_digit",
                 query: {
                   bool: {
@@ -177,7 +185,9 @@ describe DataMagic::QueryBuilder do
           bool: { 
             filter: {
               nested: {
-                inner_hits: {},
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                },
                 path: "2016.programs.cip_4_digit",
                 query: {
                   bool: {
@@ -204,7 +214,9 @@ describe DataMagic::QueryBuilder do
         { bool: { 
           filter: {
             nested: {
-              inner_hits: {},
+              inner_hits: {
+                  size: DataMagic::MAX_NESTED_RESULT
+              },
               path: "2016.programs.cip_4_digit",
               query: {
                 bool: {
@@ -235,7 +247,9 @@ describe DataMagic::QueryBuilder do
           bool: { 
             filter: {
               nested: {
-                inner_hits: {},
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                },
                 path: "2016.programs.cip_4_digit",
                 query: {
                   bool: {
@@ -390,7 +404,9 @@ describe DataMagic::QueryBuilder do
                     }]
                   }
                 },
-                inner_hits: {}
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                }
               }
             }
           }
@@ -420,7 +436,9 @@ describe DataMagic::QueryBuilder do
                     }]
                   }
                 },
-                inner_hits: {}
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                }
               }
             }
           }
@@ -450,7 +468,9 @@ describe DataMagic::QueryBuilder do
                     }]
                   }
                 },
-                inner_hits: {}
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                }
               }
             }
           }
@@ -489,7 +509,9 @@ describe DataMagic::QueryBuilder do
                     }]
                   }
                 },
-                inner_hits: {}
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                }
               }
             }
           }
@@ -521,7 +543,9 @@ describe DataMagic::QueryBuilder do
                     }]
                   }
                 },
-                inner_hits: {}
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                }
               }
             }
           }
@@ -551,7 +575,9 @@ describe DataMagic::QueryBuilder do
                     }]
                   }
                 },
-                inner_hits: {}
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                }
               }
             }
           }
@@ -590,7 +616,9 @@ describe DataMagic::QueryBuilder do
                     }]
                   }
                 },
-                inner_hits: {}
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                }
               }
             }
           }
@@ -629,7 +657,9 @@ describe DataMagic::QueryBuilder do
                     }]
                   }
                 },
-                inner_hits: {}
+                inner_hits: {
+                    size: DataMagic::MAX_NESTED_RESULT
+                }
               }
             }
           }


### PR DESCRIPTION
Added size parameter for nested query searches.  Leaving size undefined returns 3 `inner_hit` results by default.

More Info: [inner_hits options](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/search-request-inner-hits.html#_options)